### PR TITLE
Change license metadata field to a valid SPDX identifier

### DIFF
--- a/src/eblurhash.app.src
+++ b/src/eblurhash.app.src
@@ -6,6 +6,6 @@
     {env, []},
     {modules, []},
     {maintainers, ["Zotonic Team"]},
-    {licenses, ["Apache 2.0"]},
+    {licenses, ["Apache-2.0"]},
     {links, [{"GitHub", "https://github.com/zotonic/eblurhash"}]}
 ]}.


### PR DESCRIPTION
Not mandatory, but recommended for hex.pm. https://hex.pm/docs/publish#adding-metadata-to-code-classinlinemixexscode

Can be useful for a project like https://github.com/Cantido/hex_licenses