### PR TITLE
Obey CPPFLAGS/CFLAGS/LDFLAGS in Makefile.

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -11,23 +11,21 @@ C_SRC_OUTPUT ?= $(CURDIR)/../priv/blurhash
 UNAME_SYS := $(shell uname -s)
 ifeq ($(UNAME_SYS), Darwin)
 	CC ?= cc
-	CFLAGS ?= -O3 -std=c99 -arch x86_64 -finline-functions -Wall -Wmissing-prototypes
-	CXXFLAGS ?= -O3 -arch x86_64 -finline-functions -Wall
+	CFLAGS ?= -O3 -arch x86_64 -Wall -Wmissing-prototypes
 	LDFLAGS ?= -arch x86_64 -flat_namespace -undefined suppress
 else ifeq ($(UNAME_SYS), FreeBSD)
 	CC ?= cc
-	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
-	CXXFLAGS ?= -O3 -finline-functions -Wall
+	CFLAGS ?= -O3 -Wall -Wmissing-prototypes
 else ifeq ($(UNAME_SYS), Linux)
 	CC ?= gcc
-	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
-	CXXFLAGS ?= -O3 -finline-functions -Wall
+	CFLAGS ?= -O3 -Wall -Wmissing-prototypes
 endif
-
+CFLAGS_BLURHASH=-std=c99 -finline-functions $(CFLAGS)
 PROGRAM=blurhash
 
 $(C_SRC_OUTPUT): blurhash_stb.c encode.c encode.h stb_image.h
-	$(CC) -o $@ blurhash_stb.c encode.c -lm
+	$(CC) -o $@ $(CPPFLAGS) $(CFLAGS_BLURHASH) blurhash_stb.c encode.c \
+		$(LDFLAGS) -lm
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
The Makefile ignores all flags that it sets.  More importantly, it also ignores flags set by the user or build system, which generally leads to problems.